### PR TITLE
Made the code much cleaner

### DIFF
--- a/examples/stream.rs
+++ b/examples/stream.rs
@@ -4,7 +4,12 @@ use std::{thread::sleep, time::Duration};
 
 #[cfg(feature = "aesthetic")]
 fn main() {
-    let mut sp = Spinner::new_with_stream(spinners::Aesthetic, "Loading in stderr...", None, Streams::Stderr);
+    let mut sp = Spinner::new_with_stream(
+        spinners::Aesthetic,
+        "Loading in stderr...",
+        None,
+        Streams::Stderr,
+    );
     sleep(Duration::from_millis(8000));
     sp.success("Done!");
 }

--- a/src/color.rs
+++ b/src/color.rs
@@ -1,4 +1,3 @@
-use crate::Streams;
 use colored::{ColoredString, Colorize};
 
 /// Color for spinner. Supports the 8 basic colors and a custom color variant.
@@ -27,18 +26,6 @@ pub fn colorize(color: Option<Color>, frame: &str) -> ColoredString {
         Some(Color::Black) => frame.black(),
         Some(Color::Magenta) => frame.magenta(),
         Some(Color::TrueColor { r, g, b }) => frame.truecolor(r, g, b),
-        None => frame.normal()
+        None => frame.normal(),
     }
 }
-
-/// Internal function for deleting the last line in a terminal.
-/// This is used to clear the spinner.
-pub fn delete_last_line(clear_length: usize, stream: Streams) {
-    write!(stream, "\r");
-    for _ in 0..clear_length {
-        write!(stream, " ");
-    }
-    write!(stream, "\r");
-}
-
-

--- a/src/spinners.rs
+++ b/src/spinners.rs
@@ -537,7 +537,7 @@ spinner_frames!(
 spinner_frames!("speaker", ["🔈 ", "🔉 ", "🔊 ", "🔉 "], 160);
 
 spinner_frames!("orange_pulse", ["🔸 ", "🔶 ", "🟠 ", "🟠 ", "🔶 "], 100);
- 
+
 spinner_frames!("blue_pulse", ["🔹 ", "🔷 ", "🔵 ", "🔵 ", "🔷 "], 100);
 
 spinner_frames!(

--- a/src/streams.rs
+++ b/src/streams.rs
@@ -24,5 +24,11 @@ impl Streams {
     {
         write!(self.get_stream(), "{fmt}").expect("error: failed to write to stream");
     }
-
+}
+pub fn delete_last_line(clear_length: usize, stream: Streams) {
+    write!(stream, "\r");
+    for _ in 0..clear_length {
+        write!(stream, " ");
+    }
+    write!(stream, "\r");
 }


### PR DESCRIPTION
It's hard to work with code that is hard to read so I did these changes:
-removed utils.rs because the name is undescriptive, put color stuff in color.rs and delete_last_line() in streams.rs
-ran cargo fmt (you should always run it)
-extracted several code snippets to separate functions
There were some quirks but I'll try to fix them